### PR TITLE
Add contributing guidelines file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+Contributing guidelines
+=======================
+
+See the [MagicBox contributing
+guidelines](https://github.com/unicef/magicbox/blob/master/.github/CONTRIBUTING.md)
+first for general guidelines that apply to _all_ MagicBox projects!
+
+
+## Checklist for coordinates_to_admin_id_server
+
+Before submitting a new pull request to this repo, follow these steps:
+
+1. Follow [MagicBox contributing
+   guidelines](https://github.com/unicef/magicbox/blob/master/.github/CONTRIBUTING.md)
+2. Run all unit tests (`npm test`)


### PR DESCRIPTION
This adds a CONTRIBUTING.md file, like we've added to other repos. It mostly points to the primary contributing guidelines and tries to create a basic checklist for new contributors to follow.