### PR TITLE
Use latest RTD image, build docs with Travis

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+build:
+  image: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
 cache:
   directories:
     - "node_modules"
+script:
+  - ./docs/test-docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ matrix:
           - "node_modules"
 
     # Documentation
-    - language: python
-      sudo: required
-      python: 3.5
-      install:
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq jsdoc-toolkit
-        - pip install -r docs/requirements.txt
-      script:
-        - ./docs/test-docs.sh
+    #- language: python
+    #  sudo: required
+    #  python: 3.5
+    #  install:
+    #    - sudo apt-get update -qq
+    #    - sudo apt-get install -qq jsdoc-toolkit
+    #    - pip install -r docs/requirements.txt
+    #  script:
+    #    - ./docs/test-docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
-language: node_js
-node_js:
-  - "8"
-cache:
-  directories:
-    - "node_modules"
-script:
-  - ./docs/test-docs.sh
+matrix:
+  include:
+
+    # Code
+    - language: node_js
+      node_js: 8
+      cache:
+        directories:
+          - "node_modules"
+
+    # Documentation
+    - language: python
+      sudo: required
+      python: 3.5
+      install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq jsdoc-toolkit
+        - pip install -r docs/requirements.txt
+      script:
+        - ./docs/test-docs.sh

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,10 +31,11 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.imgmath',
-    'sphinx_js']
+extensions = ['sphinx_js']
+
+# Set all *.js as "code" documents
+# https://github.com/erikrose/sphinx-js#saving-keystrokes-by-setting-the-primary-domain
+primary_domain = 'js'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -174,7 +175,7 @@ texinfo_documents = [
 ]
 
 
+# -- Options for jsdoc ----------------------------------------------------
+# https://github.com/erikrose/sphinx-js#configuration-reference
 
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+js_source_path = '../src'


### PR DESCRIPTION
In my last PR, the docs built correctly locally, but not on the ReadTheDocs site (because `jsdoc` is only available in their latest images). This PR does two things:

* **ReadTheDocs**: Use latest image so we can pull in `jsdoc`
* **TravisCI**: Build our docs as part of the CI